### PR TITLE
Add support for MaxConcurrentCalls  to RabbitMQClient

### DIFF
--- a/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQueueClient.cs
@@ -144,6 +144,14 @@ namespace Enable.Extensions.Queuing.RabbitMQ.Internal
             Func<IQueueMessage, CancellationToken, Task> messageHandler,
             MessageHandlerOptions messageHandlerOptions)
         {
+            if (messageHandlerOptions.MaxConcurrentCalls > ushort.MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(messageHandlerOptions.MaxConcurrentCalls),
+                    messageHandlerOptions.MaxConcurrentCalls,
+                    $@"'{nameof(messageHandlerOptions.MaxConcurrentCalls)}' must be less than or equal to {ushort.MaxValue}.");
+            }
+
             // Reconfigure quality of service on the channel in order to
             // support specified level of concurrency. Here we are changing
             // the prefetch count to a user-specified `MaxConcurrentCalls`.

--- a/src/Enable.Extensions.Queuing.RabbitMQ/Internal/TaskExtensions.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Internal/TaskExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Threading.Tasks;
+
+namespace Enable.Extensions.Queuing.RabbitMQ.Internal
+{
+    public static class TaskExtensions
+    {
+        public static void Ignore(this Task task)
+        {
+        }
+    }
+}


### PR DESCRIPTION
This PR adds support for `MaxConcurrentCalls`, which the `RabbitMQClient` previous lacked. This was needed to have the option for parallelising the processing of messages / calls to the message handler.

Before merging this PR, we should discuss the changes and the merits and pitfalls of this approach.

- Does it align the behaviour with the `AzureServiceBusClient`?
- Does it matter that message processing order isn't maintained?
- Is there a better solution to this problem?