### PR TITLE
Allow Azure Storage Emulator to be used with Azure Queues.

### DIFF
--- a/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueClient.cs
@@ -26,6 +26,7 @@ namespace Enable.Extensions.Queuing.AzureStorage.Internal
             string queueName)
         {
             var credentials = new StorageCredentials(accountName, accountKey);
+            CloudStorageAccount storageAccount;
 
             // Get storage account object differently if it is the local development account
             if (credentials.AccountName == "devstoreaccount1")

--- a/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueClient.cs
@@ -26,7 +26,16 @@ namespace Enable.Extensions.Queuing.AzureStorage.Internal
             string queueName)
         {
             var credentials = new StorageCredentials(accountName, accountKey);
-            var storageAccount = new CloudStorageAccount(credentials, useHttps: true);
+
+            // Get storage account object differently if it is the local development account
+            if (credentials.AccountName == "devstoreaccount1")
+            {
+                storageAccount = CloudStorageAccount.Parse("UseDevelopmentStorage=true;");
+            }
+            else
+            {
+                storageAccount = new CloudStorageAccount(credentials, useHttps: true);
+            }
 
             var client = storageAccount.CreateCloudQueueClient();
 


### PR DESCRIPTION
The default way a storage account reference is obtained causes a 403 forbidden exception to be thrown if the debug configuration is set to use the local Azure Storage Emulator.