### PR TITLE
Add support for batch message sending

### DIFF
--- a/src/Enable.Extensions.Queuing.Abstractions/IQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/IQueueClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -58,6 +59,20 @@ namespace Enable.Extensions.Queuing.Abstractions
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Asynchronously enqueue a batch of messages on to the queue.
+        /// </summary>
+        /// <param name="messages">The collection of messages to enqueue.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to observe while waiting for a task to complete.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        Task EnqueueAsync(
+            IEnumerable<IQueueMessage> messages,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Asynchronously enqueue a message on to the queue.
         /// </summary>
         /// <param name="content">The payload of the message to enqueue.</param>
@@ -98,6 +113,21 @@ namespace Enable.Extensions.Queuing.Abstractions
         /// </returns>
         Task EnqueueAsync<T>(
             T content,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously enqueue a batch of messages on to the queue.
+        /// </summary>
+        /// <typeparam name="T">The type of the payload to enqueue.</typeparam>
+        /// <param name="messages">The collection of payload items to enqueue.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to observe while waiting for a task to complete.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        Task EnqueueAsync<T>(
+            IEnumerable<T> messages,
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>

--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Enable.Extensions.Queuing.Abstractions;
@@ -67,7 +68,21 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
             IQueueMessage message,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return _messageSender.SendAsync(new Message(message.Body) { ContentType = "application/json" });
+            return _messageSender.SendAsync(CreateMessage(message));
+        }
+
+        public override Task EnqueueAsync(
+            IEnumerable<IQueueMessage> messages,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var messageList = new List<Message>();
+
+            foreach (var message in messages)
+            {
+                messageList.Add(CreateMessage(message));
+            }
+
+            return _messageSender.SendAsync(messageList);
         }
 
         public override Task RegisterMessageHandler(
@@ -139,6 +154,14 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
             }
 
             return ExceptionReceivedHandler;
+        }
+
+        private Message CreateMessage(IQueueMessage message)
+        {
+            return new Message(message.Body)
+            {
+                ContentType = "application/json"
+            };
         }
     }
 }

--- a/src/Enable.Extensions.Queuing.InMemory/Internal/InMemoryQueue.cs
+++ b/src/Enable.Extensions.Queuing.InMemory/Internal/InMemoryQueue.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Enable.Extensions.Queuing.Abstractions;
@@ -55,6 +56,18 @@ namespace Enable.Extensions.Queuing.InMemory.Internal
                 // throws an exception, then we simply queue the message.
                 _queue.Enqueue(message);
             }
+        }
+
+        public Task EnqueueAsync(IEnumerable<IQueueMessage> messages)
+        {
+            var tasks = new List<Task>();
+
+            foreach (var message in messages)
+            {
+                tasks.Add(EnqueueAsync(message));
+            }
+
+            return Task.WhenAll(tasks);
         }
 
         public int IncrementReferenceCount()

--- a/src/Enable.Extensions.Queuing.InMemory/Internal/InMemoryQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.InMemory/Internal/InMemoryQueueClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Enable.Extensions.Queuing.Abstractions;
@@ -13,12 +14,12 @@ namespace Enable.Extensions.Queuing.InMemory.Internal
     /// <para>
     /// This queue implementation is useful when you want to test components
     /// using something that approximates connecting to a real queue, without
-    /// the overhead of actual queue operations. 
+    /// the overhead of actual queue operations.
     /// </para>
     /// <para>
     /// This queue implementation is intended to be used in test code only.
     /// This queue is only valid for the lifetime of the host process and
-    /// cannot be used for inter-process communication. 
+    /// cannot be used for inter-process communication.
     /// </para>
     /// </remarks>
     internal class InMemoryQueueClient : BaseQueueClient
@@ -84,6 +85,15 @@ namespace Enable.Extensions.Queuing.InMemory.Internal
             ThrowIfDisposed();
 
             return _queue.EnqueueAsync(message);
+        }
+
+        public override Task EnqueueAsync(
+            IEnumerable<IQueueMessage> messages,
+            CancellationToken cancellationToken = default(CancellationToken))
+        {
+            ThrowIfDisposed();
+
+            return _queue.EnqueueAsync(messages);
         }
 
         public override Task RegisterMessageHandler(

--- a/test/Enable.Extensions.Queuing.AzureServiceBus.Tests/AzureServiceBusQueueClientTests.cs
+++ b/test/Enable.Extensions.Queuing.AzureServiceBus.Tests/AzureServiceBusQueueClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -72,6 +73,26 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Tests
             // Clean up
             var message = await _sut.DequeueAsync(CancellationToken.None);
             await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithMultipleMessages()
+        {
+            // Arrange
+            var messages = new List<string>
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            // Act
+            await _sut.EnqueueAsync<string>(messages, CancellationToken.None);
+
+            // Clean up
+            var message1 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message1, CancellationToken.None);
+            var message2 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message2, CancellationToken.None);
         }
 
         [Fact]

--- a/test/Enable.Extensions.Queuing.AzureStorage.Tests/AzureStorageQueueClientTests.cs
+++ b/test/Enable.Extensions.Queuing.AzureStorage.Tests/AzureStorageQueueClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -73,6 +74,26 @@ namespace Enable.Extensions.Queuing.AzureStorage.Tests
             // Clean up
             var message = await _sut.DequeueAsync(CancellationToken.None);
             await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithMultipleMessages()
+        {
+            // Arrange
+            var messages = new List<string>
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            // Act
+            await _sut.EnqueueAsync<string>(messages, CancellationToken.None);
+
+            // Clean up
+            var message1 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message1, CancellationToken.None);
+            var message2 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message2, CancellationToken.None);
         }
 
         [Fact]

--- a/test/Enable.Extensions.Queuing.InMemory.Tests/InMemoryQueueClientTests.cs
+++ b/test/Enable.Extensions.Queuing.InMemory.Tests/InMemoryQueueClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -67,6 +68,26 @@ namespace Enable.Extensions.Queuing.InMemory.Tests
             // Clean up
             var message = await _sut.DequeueAsync(CancellationToken.None);
             await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithMultipleMessages()
+        {
+            // Arrange
+            var messages = new List<string>
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            // Act
+            await _sut.EnqueueAsync<string>(messages, CancellationToken.None);
+
+            // Clean up
+            var message1 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message1, CancellationToken.None);
+            var message2 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message2, CancellationToken.None);
         }
 
         [Fact]
@@ -277,12 +298,12 @@ namespace Enable.Extensions.Queuing.InMemory.Tests
 
                 var messageHandled = false;
 
-               Func<IQueueMessage, CancellationToken, Task> handler
-                    = (message, cancellationToken) =>
-                    {
-                        messageHandled = true;
-                        return Task.CompletedTask;
-                    };
+                Func<IQueueMessage, CancellationToken, Task> handler
+                     = (message, cancellationToken) =>
+                     {
+                         messageHandled = true;
+                         return Task.CompletedTask;
+                     };
 
                 await instance2.RegisterMessageHandler(handler);
 

--- a/test/Enable.Extensions.Queuing.RabbitMQ.Tests/RabbitMQQueueClientTests.cs
+++ b/test/Enable.Extensions.Queuing.RabbitMQ.Tests/RabbitMQQueueClientTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -76,6 +77,26 @@ namespace Enable.Extensions.Queuing.RabbitMQ.Tests
             // Clean up
             var message = await _sut.DequeueAsync(CancellationToken.None);
             await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithMultipleMessages()
+        {
+            // Arrange
+            var messages = new List<string>
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            // Act
+            await _sut.EnqueueAsync<string>(messages, CancellationToken.None);
+
+            // Clean up
+            var message1 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message1, CancellationToken.None);
+            var message2 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message2, CancellationToken.None);
         }
 
         [Fact]


### PR DESCRIPTION
Azure Service Bus and RabbitMQ both support sending messages in batches. This functionality is now exposed to end users, and workarounds have been put in place for providers that do no offer batching.