### PR TITLE
Remove casing of Service Bus variables

### DIFF
--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
@@ -26,9 +26,6 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
             string connectionString,
             string queueName)
         {
-            connectionString = connectionString.ToLowerInvariant();
-            queueName = queueName.ToLowerInvariant();
-
             _queueKey = $"{connectionString}:{queueName}".GetHashCode();
 
             _queue = _queues.AddOrUpdate(


### PR DESCRIPTION
`AzureServiceBusQueueClient` converts the connection string and queue name passed in to lowercase when creating the key for internal cache of queues. However, the two lowercased variables are then used to initialise the Service Bus queue, causing an unauthorised exception to be thrown.

The casing has been removed, which is inline with how the [Azure WebJobs SDK creates a similar key](https://github.com/Azure/azure-webjobs-sdk/blob/c5322c05776481128911cc59dbaa116fab8039fd/src/Microsoft.Azure.WebJobs.Extensions.ServiceBus/MessagingProvider.cs#L98).