### PR TITLE
Add support for Session ID

### DIFF
--- a/src/Enable.Extensions.Queuing.Abstractions/BaseQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/BaseQueueClient.cs
@@ -11,14 +11,14 @@ namespace Enable.Extensions.Queuing.Abstractions
     {
         public abstract Task AbandonAsync(
             IQueueMessage message,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         public abstract Task CompleteAsync(
             IQueueMessage message,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         public abstract Task<IQueueMessage> DequeueAsync(
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         public void Dispose()
         {
@@ -28,36 +28,36 @@ namespace Enable.Extensions.Queuing.Abstractions
 
         public abstract Task EnqueueAsync(
             IQueueMessage message,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         public abstract Task EnqueueAsync(
             IEnumerable<IQueueMessage> messages,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         public Task EnqueueAsync(
             byte[] content,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             return EnqueueAsync(content, null, cancellationToken);
         }
 
         public Task EnqueueAsync(
             string content,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             return EnqueueAsync(content, null, cancellationToken);
         }
 
         public Task EnqueueAsync<T>(
             T content,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             return EnqueueAsync(content, null, cancellationToken);
         }
 
         public Task EnqueueAsync<T>(
             IEnumerable<T> messages,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             return EnqueueAsync(messages, null, cancellationToken);
         }
@@ -119,7 +119,7 @@ namespace Enable.Extensions.Queuing.Abstractions
 
         public abstract Task RenewLockAsync(
             IQueueMessage message,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         protected virtual void Dispose(bool disposing)
         {

--- a/src/Enable.Extensions.Queuing.Abstractions/BaseQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/BaseQueueClient.cs
@@ -38,45 +38,34 @@ namespace Enable.Extensions.Queuing.Abstractions
             byte[] content,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            IQueueMessage message = new QueueMessage(content);
-
-            return EnqueueAsync(message, cancellationToken);
+            return EnqueueAsync(content, null, cancellationToken);
         }
 
         public Task EnqueueAsync(
             string content,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            return EnqueueAsync<string>(content, cancellationToken);
+            return EnqueueAsync(content, null, cancellationToken);
         }
 
         public Task EnqueueAsync<T>(
             T content,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var message = SerializeQueueMessage(content);
-
-            return EnqueueAsync(message, cancellationToken);
+            return EnqueueAsync(content, null, cancellationToken);
         }
 
         public Task EnqueueAsync<T>(
             IEnumerable<T> messages,
             CancellationToken cancellationToken = default(CancellationToken))
         {
-            var batch = new List<IQueueMessage>();
-
-            foreach (var message in messages)
-            {
-                batch.Add(SerializeQueueMessage(message));
-            }
-
-            return EnqueueAsync(messages: batch, cancellationToken: cancellationToken);
+            return EnqueueAsync(messages, null, cancellationToken);
         }
 
         public Task EnqueueAsync(
             byte[] content,
             string sessionId,
-            CancellationToken cancellationToken = default(CancellationToken))
+            CancellationToken cancellationToken = default)
         {
             IQueueMessage message = new QueueMessage(content, sessionId);
 
@@ -134,15 +123,6 @@ namespace Enable.Extensions.Queuing.Abstractions
 
         protected virtual void Dispose(bool disposing)
         {
-        }
-
-        private IQueueMessage SerializeQueueMessage<T>(T content)
-        {
-            var json = JsonConvert.SerializeObject(content);
-
-            var payload = Encoding.UTF8.GetBytes(json);
-
-            return new QueueMessage(payload);
         }
 
         private IQueueMessage SerializeQueueMessage<T>(T content, string sessionId)

--- a/src/Enable.Extensions.Queuing.Abstractions/BaseQueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/BaseQueueMessage.cs
@@ -9,6 +9,8 @@ namespace Enable.Extensions.Queuing.Abstractions
 
         public abstract string LeaseId { get; }
 
+        public abstract string SessionId { get; }
+
         public abstract uint DequeueCount { get; }
 
         public abstract byte[] Body { get; }

--- a/src/Enable.Extensions.Queuing.Abstractions/IQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/IQueueClient.cs
@@ -131,6 +131,72 @@ namespace Enable.Extensions.Queuing.Abstractions
             CancellationToken cancellationToken = default(CancellationToken));
 
         /// <summary>
+        /// Asynchronously enqueue a message on to the queue, with a session ID.
+        /// </summary>
+        /// <param name="content">The payload of the message to enqueue.</param>
+        /// <param name="sessionId">The session ID to attach to the message.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to observe while waiting for a task to complete.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        Task EnqueueAsync(
+            byte[] content,
+            string sessionId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously enqueue a message on to the queue, with a session ID.
+        /// </summary>
+        /// <param name="content">The payload of the message to enqueue.</param>
+        /// <param name="sessionId">The session ID to attach to the message.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to observe while waiting for a task to complete.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        Task EnqueueAsync(
+            string content,
+            string sessionId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously enqueue a message on to the queue, with a session ID.
+        /// </summary>
+        /// <typeparam name="T">The type of the payload to enqueue.</typeparam>
+        /// <param name="content">The payload of the message to enqueue.</param>
+        /// <param name="sessionId">The session ID to attach to the message.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to observe while waiting for a task to complete.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        Task EnqueueAsync<T>(
+            T content,
+            string sessionId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
+        /// Asynchronously enqueue a batch of messages on to the queue, with a shared session ID.
+        /// </summary>
+        /// <typeparam name="T">The type of the payload to enqueue.</typeparam>
+        /// <param name="messages">The collection of payload items to enqueue.</param>
+        /// <param name="sessionId">The session ID to attach to the messages.</param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> to observe while waiting for a task to complete.
+        /// </param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the asynchronous operation.
+        /// </returns>
+        Task EnqueueAsync<T>(
+            IEnumerable<T> messages,
+            string sessionId,
+            CancellationToken cancellationToken = default(CancellationToken));
+
+        /// <summary>
         /// Register a message handler. This handler is awaited each time that
         /// a new message is received.
         /// </summary>

--- a/src/Enable.Extensions.Queuing.Abstractions/IQueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/IQueueMessage.cs
@@ -26,6 +26,14 @@ namespace Enable.Extensions.Queuing.Abstractions
         string LeaseId { get; }
 
         /// <summary>
+        /// Gets the session ID.
+        /// </summary>
+        /// <remarks>
+        /// The session ID is used to mark a relationship between messages.
+        /// </remarks>
+        string SessionId { get; }
+
+        /// <summary>
         /// Gets the number of times this message has been dequeued.
         /// </summary>
         uint DequeueCount { get; }

--- a/src/Enable.Extensions.Queuing.Abstractions/QueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/QueueMessage.cs
@@ -3,15 +3,24 @@ namespace Enable.Extensions.Queuing.Abstractions
     internal class QueueMessage : BaseQueueMessage
     {
         private readonly byte[] _payload;
+        private readonly string _sessionId;
 
         public QueueMessage()
         {
             _payload = new byte[0];
+            _sessionId = null;
         }
 
         public QueueMessage(byte[] payload)
         {
             _payload = payload;
+            _sessionId = null;
+        }
+
+        public QueueMessage(byte[] payload, string sessionId)
+        {
+            _payload = payload;
+            _sessionId = sessionId;
         }
 
         public override byte[] Body => _payload;
@@ -22,6 +31,6 @@ namespace Enable.Extensions.Queuing.Abstractions
 
         public override string MessageId { get; }
 
-        public override string SessionId => throw new System.NotImplementedException();
+        public override string SessionId => _sessionId;
     }
 }

--- a/src/Enable.Extensions.Queuing.Abstractions/QueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/QueueMessage.cs
@@ -21,5 +21,7 @@ namespace Enable.Extensions.Queuing.Abstractions
         public override string LeaseId => throw new System.NotImplementedException();
 
         public override string MessageId { get; }
+
+        public override string SessionId => throw new System.NotImplementedException();
     }
 }

--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
@@ -192,6 +192,11 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
                 message.MessageId = queueMessage.MessageId;
             }
 
+            if (!string.IsNullOrEmpty(queueMessage.SessionId))
+            {
+                message.SessionId = queueMessage.SessionId;
+            }
+
             return message;
         }
     }

--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueMessage.cs
@@ -19,5 +19,7 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
         public override uint DequeueCount => (uint)_message.SystemProperties.DeliveryCount;
 
         public override string LeaseId => _message.SystemProperties.LockToken;
+
+        public override string SessionId => _message.SessionId;
     }
 }

--- a/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueMessage.cs
@@ -19,6 +19,8 @@ namespace Enable.Extensions.Queuing.AzureStorage.Internal
 
         public override string LeaseId => _leaseId;
 
+        public override string SessionId => null;
+
         public override uint DequeueCount => (uint)_message.DequeueCount;
 
         public override byte[] Body => _message.AsBytes;

--- a/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQueueMessage.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQueueMessage.cs
@@ -30,5 +30,7 @@ namespace Enable.Extensions.Queuing.RabbitMQ.Internal
         public override string LeaseId { get; }
 
         public override string MessageId { get; }
+
+        public override string SessionId => null;
     }
 }

--- a/test/Enable.Extensions.Queuing.AzureServiceBus.Tests/AzureServiceBusQueueClientTests.cs
+++ b/test/Enable.Extensions.Queuing.AzureServiceBus.Tests/AzureServiceBusQueueClientTests.cs
@@ -97,6 +97,165 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Tests
         }
 
         [Fact]
+        public async Task EnqueueAsync_CanInvokeWithStringAndSessionId()
+        {
+            // Arrange
+            var content = Guid.NewGuid().ToString();
+            var sessionId = Guid.NewGuid().ToString();
+
+            // Act
+            await _sut.EnqueueAsync(content, sessionId, CancellationToken.None);
+
+            // Clean up
+            var message = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_InvokeWithStringSetsSessionId()
+        {
+            // Arrange
+            var content = Guid.NewGuid().ToString();
+            var sessionId = "session-id";
+
+            // Act
+            await _sut.EnqueueAsync(content, sessionId, CancellationToken.None);
+
+            var message = await _sut.DequeueAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Equal(sessionId, message.SessionId);
+
+            // Clean up
+            await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithByteArrayAndSessionId()
+        {
+            // Arrange
+            var content = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString());
+            var sessionId = Guid.NewGuid().ToString();
+
+            // Act
+            await _sut.EnqueueAsync(content, sessionId, CancellationToken.None);
+
+            // Clean up
+            var message = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_InvokeWithByteArraySetsSessionId()
+        {
+            // Arrange
+            var content = Encoding.UTF8.GetBytes(Guid.NewGuid().ToString());
+            var sessionId = "session-id";
+
+            // Act
+            await _sut.EnqueueAsync(content, sessionId, CancellationToken.None);
+
+            var message = await _sut.DequeueAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Equal(sessionId, message.SessionId);
+
+            // Clean up
+            await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithCustomMessageTypeAndSessionId()
+        {
+            // Arrange
+            var content = new CustomMessageType
+            {
+                Message = Guid.NewGuid().ToString()
+            };
+
+            var sessionId = Guid.NewGuid().ToString();
+
+            // Act
+            await _sut.EnqueueAsync(content, sessionId, CancellationToken.None);
+
+            // Clean up
+            var message = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_InvokeWithCustomMessageTypeSetsSessionId()
+        {
+            // Arrange
+            var content = new CustomMessageType
+            {
+                Message = Guid.NewGuid().ToString()
+            };
+
+            var sessionId = "session-id";
+
+            // Act
+            await _sut.EnqueueAsync(content, sessionId, CancellationToken.None);
+
+            var message = await _sut.DequeueAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Equal(sessionId, message.SessionId);
+
+            // Clean up
+            await _sut.CompleteAsync(message, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_CanInvokeWithMultipleMessagesAndSessionId()
+        {
+            // Arrange
+            var messages = new List<string>
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            var sessionId = Guid.NewGuid().ToString();
+
+            // Act
+            await _sut.EnqueueAsync<string>(messages, sessionId, CancellationToken.None);
+
+            // Clean up
+            var message1 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message1, CancellationToken.None);
+            var message2 = await _sut.DequeueAsync(CancellationToken.None);
+            await _sut.CompleteAsync(message2, CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EnqueueAsync_InvokeWithMultipleMessagesSetsSessionId()
+        {
+            // Arrange
+            var messages = new List<string>
+            {
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString()
+            };
+
+            var sessionId = "session-id";
+
+            // Act
+            await _sut.EnqueueAsync<string>(messages, sessionId, CancellationToken.None);
+            var message1 = await _sut.DequeueAsync(CancellationToken.None);
+            var message2 = await _sut.DequeueAsync(CancellationToken.None);
+
+            // Assert
+
+            Assert.Equal(sessionId, message1.SessionId);
+            Assert.Equal(sessionId, message2.SessionId);
+
+            // Clean up
+            await _sut.CompleteAsync(message1, CancellationToken.None);
+            await _sut.CompleteAsync(message2, CancellationToken.None);
+        }
+
+        [Fact]
         public async Task DequeueAsync_CanInvoke()
         {
             // Act

--- a/test/Enable.Extensions.Queuing.AzureServiceBus.Tests/AzureServiceBusQueueClientTests.cs
+++ b/test/Enable.Extensions.Queuing.AzureServiceBus.Tests/AzureServiceBusQueueClientTests.cs
@@ -246,7 +246,6 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Tests
             var message2 = await _sut.DequeueAsync(CancellationToken.None);
 
             // Assert
-
             Assert.Equal(sessionId, message1.SessionId);
             Assert.Equal(sessionId, message2.SessionId);
 


### PR DESCRIPTION
This change allows a session ID to be passed when queuing messages. If the underlying provider supports sessions or a similar technology, the session ID is attached to the message. In this case, only Azure service bus supports sessions.