### PR TITLE
Extend MaxAutoRenewDuration to an hour

### DIFF
--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
@@ -119,7 +119,7 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
             {
                 AutoComplete = messageHandlerOptions.AutoComplete,
                 MaxConcurrentCalls = messageHandlerOptions.MaxConcurrentCalls,
-                MaxAutoRenewDuration = TimeSpan.FromMinutes(5)
+                MaxAutoRenewDuration = TimeSpan.FromMinutes(60)
             };
 
             _messageReceiver.RegisterMessageHandler(

--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Internal/AzureServiceBusQueueClient.cs
@@ -119,7 +119,7 @@ namespace Enable.Extensions.Queuing.AzureServiceBus.Internal
             {
                 AutoComplete = messageHandlerOptions.AutoComplete,
                 MaxConcurrentCalls = messageHandlerOptions.MaxConcurrentCalls,
-                MaxAutoRenewDuration = TimeSpan.FromMinutes(60)
+                MaxAutoRenewDuration = TimeSpan.FromHours(1)
             };
 
             _messageReceiver.RegisterMessageHandler(


### PR DESCRIPTION
Extend `MaxAutoRenewDuration` from 5 minutes to an hour to allow for messages that take longer than 5 minutes to process.
