### PR TITLE
Downgrade to net standard 2.0

### DIFF
--- a/src/Enable.Extensions.Queuing.Abstractions/Enable.Extensions.Queuing.Abstractions.csproj
+++ b/src/Enable.Extensions.Queuing.Abstractions/Enable.Extensions.Queuing.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Queuing.AzureServiceBus/Enable.Extensions.Queuing.AzureServiceBus.csproj
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/Enable.Extensions.Queuing.AzureServiceBus.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Queuing.AzureStorage/Enable.Extensions.Queuing.AzureStorage.csproj
+++ b/src/Enable.Extensions.Queuing.AzureStorage/Enable.Extensions.Queuing.AzureStorage.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Queuing.Discovery/Enable.Extensions.Queuing.Discovery.csproj
+++ b/src/Enable.Extensions.Queuing.Discovery/Enable.Extensions.Queuing.Discovery.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Queuing.InMemory/Enable.Extensions.Queuing.InMemory.csproj
+++ b/src/Enable.Extensions.Queuing.InMemory/Enable.Extensions.Queuing.InMemory.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 

--- a/src/Enable.Extensions.Queuing.RabbitMQ/Enable.Extensions.Queuing.RabbitMQ.csproj
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Enable.Extensions.Queuing.RabbitMQ.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\..\CustomExtendedCorrectnessRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
 


### PR DESCRIPTION
Downgrade to net standard 2.0. The initial upgrade to 2.1 seems unnecessary, and downgrading improves compatability.