### PR TITLE
Add an optional dead letter queue name parameter 

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ namespace QueuingSamples
 
             // Get a reference to the queue that you want to work with.
             // The queue will be automatically created if it doesn't exist.
+            // The dead letter queue name can optionally be passed into this method.
             using (var queue = queueFactory.GetQueueReference(queueName))
             {
                 // Add a new item to the queue.

--- a/src/Enable.Extensions.Queuing.Abstractions/IQueueClientFactory.cs
+++ b/src/Enable.Extensions.Queuing.Abstractions/IQueueClientFactory.cs
@@ -1,7 +1,7 @@
-﻿namespace Enable.Extensions.Queuing.Abstractions
+namespace Enable.Extensions.Queuing.Abstractions
 {
     public interface IQueueClientFactory
     {
-        IQueueClient GetQueueReference(string queueName);
+        IQueueClient GetQueueReference(string queueName, string deadLetterQueueName = null);
     }
 }

--- a/src/Enable.Extensions.Queuing.AzureServiceBus/AzureServiceBusQueueClientFactory.cs
+++ b/src/Enable.Extensions.Queuing.AzureServiceBus/AzureServiceBusQueueClientFactory.cs
@@ -23,13 +23,14 @@ namespace Enable.Extensions.Queuing.AzureServiceBus
             _options = options;
         }
 
-        public IQueueClient GetQueueReference(string queueName)
+        public IQueueClient GetQueueReference(string queueName, string deadLetterQueueName = null)
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
                 throw new ArgumentException(nameof(queueName));
             }
 
+            // We do not currently define a dead letter queue in service bus client, so we do not pass the name.
             return new AzureServiceBusQueueClient(
                 _options.ConnectionString,
                 queueName,

--- a/src/Enable.Extensions.Queuing.AzureStorage/AzureStorageQueueClientFactory.cs
+++ b/src/Enable.Extensions.Queuing.AzureStorage/AzureStorageQueueClientFactory.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Enable.Extensions.Queuing.Abstractions;
 using Enable.Extensions.Queuing.AzureStorage.Internal;
 
@@ -28,7 +28,7 @@ namespace Enable.Extensions.Queuing.AzureStorage
             _options = options;
         }
 
-        public IQueueClient GetQueueReference(string queueName)
+        public IQueueClient GetQueueReference(string queueName, string deadLetterQueueName = null)
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
@@ -38,7 +38,8 @@ namespace Enable.Extensions.Queuing.AzureStorage
             return new AzureStorageQueueClient(
                 _options.AccountName,
                 _options.AccountKey,
-                queueName);
+                queueName,
+                deadLetterQueueName);
         }
     }
 }

--- a/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.AzureStorage/Internal/AzureStorageQueueClient.cs
@@ -24,7 +24,8 @@ namespace Enable.Extensions.Queuing.AzureStorage.Internal
         public AzureStorageQueueClient(
             string accountName,
             string accountKey,
-            string queueName)
+            string queueName,
+            string deadLetterQueueName = null)
         {
             var client = GetCloudQueueClient(accountName, accountKey, queueName);
 
@@ -37,8 +38,8 @@ namespace Enable.Extensions.Queuing.AzureStorage.Internal
 
             _deadLetterQueueFactory = new AsyncLazy<CloudQueue>(async () =>
             {
-                var deadLetterQueueName = GetDeadLetterQueueName(queueName);
-                var deadLetterQueue = client.GetQueueReference(deadLetterQueueName);
+                var finalDeadLetterQueueName = deadLetterQueueName ?? GetDeadLetterQueueName(queueName);
+                var deadLetterQueue = client.GetQueueReference(finalDeadLetterQueueName);
                 await deadLetterQueue.CreateIfNotExistsAsync();
                 return deadLetterQueue;
             });

--- a/src/Enable.Extensions.Queuing.InMemory/InMemoryQueueClientFactory.cs
+++ b/src/Enable.Extensions.Queuing.InMemory/InMemoryQueueClientFactory.cs
@@ -6,13 +6,14 @@ namespace Enable.Extensions.Queuing.InMemory
 {
     public class InMemoryQueueClientFactory : IQueueClientFactory
     {
-        public IQueueClient GetQueueReference(string queueName)
+        public IQueueClient GetQueueReference(string queueName, string deadLetterQueueName = null)
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
                 throw new ArgumentException(nameof(queueName));
             }
 
+            // We do not currently have a dead letter queue for the in-memory client, so we do not pass the name.
             return new InMemoryQueueClient(queueName);
         }
     }

--- a/src/Enable.Extensions.Queuing.RabbitMQ/Internal/BaseRabbitMQQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Internal/BaseRabbitMQQueueClient.cs
@@ -17,14 +17,15 @@ namespace Enable.Extensions.Queuing.RabbitMQ.Internal
         public BaseRabbitMQQueueClient(
             ConnectionFactory connectionFactory,
             string queueName,
-            QueueMode queueMode = QueueMode.Default)
+            QueueMode queueMode = QueueMode.Default,
+            string deadLetterQueueName = null)
         {
             ConnectionFactory = connectionFactory;
             Connection = ConnectionFactory.CreateConnection();
             Channel = Connection.CreateModel();
 
             // Declare the dead letter queue.
-            DeadLetterQueueName = GetDeadLetterQueueName(queueName);
+            DeadLetterQueueName = deadLetterQueueName ?? GetDeadLetterQueueName(queueName);
             DLQueueArguments = null;
 
             ExchangeName = string.Empty;

--- a/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQueueClient.cs
@@ -1,11 +1,4 @@
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
-using Enable.Extensions.Queuing.Abstractions;
 using RabbitMQ.Client;
-using RabbitMQ.Client.Events;
 
 namespace Enable.Extensions.Queuing.RabbitMQ.Internal
 {
@@ -14,8 +7,9 @@ namespace Enable.Extensions.Queuing.RabbitMQ.Internal
         public RabbitMQQueueClient(
             ConnectionFactory connectionFactory,
             string queueName,
-            QueueMode queueMode = QueueMode.Default)
-            : base(connectionFactory, queueName, queueMode)
+            QueueMode queueMode = QueueMode.Default,
+            string deadLetterQueueName = null)
+            : base(connectionFactory, queueName, queueMode, deadLetterQueueName)
         {
             DeclareQueues();
         }

--- a/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQuorumQueueClient.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/Internal/RabbitMQQuorumQueueClient.cs
@@ -8,8 +8,9 @@ namespace Enable.Extensions.Queuing.RabbitMQ.Internal
         public RabbitMQQuorumQueueClient(
             ConnectionFactory connectionFactory,
             string queueName,
-            QueueMode queueMode = QueueMode.Default)
-            : base(connectionFactory, queueName, queueMode)
+            QueueMode queueMode = QueueMode.Default,
+            string deadLetterQueueName = null)
+            : base(connectionFactory, queueName, queueMode, deadLetterQueueName)
         {
             QueueArguments.Add("x-queue-type", "quorum");
             DLQueueArguments = new Dictionary<string, object>

--- a/src/Enable.Extensions.Queuing.RabbitMQ/RabbitMQQueueClientFactory.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/RabbitMQQueueClientFactory.cs
@@ -11,14 +11,14 @@ namespace Enable.Extensions.Queuing.RabbitMQ
         {
         }
 
-        public IQueueClient GetQueueReference(string queueName)
+        public IQueueClient GetQueueReference(string queueName, string deadLetterQueueName = null)
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
                 throw new ArgumentException(nameof(queueName));
             }
 
-            return new RabbitMQQueueClient(ConnectionFactory, queueName, QueueMode);
+            return new RabbitMQQueueClient(ConnectionFactory, queueName, QueueMode, deadLetterQueueName);
         }
     }
 }

--- a/src/Enable.Extensions.Queuing.RabbitMQ/RabbitMQQuorumQueueClientFactory.cs
+++ b/src/Enable.Extensions.Queuing.RabbitMQ/RabbitMQQuorumQueueClientFactory.cs
@@ -11,14 +11,14 @@ namespace Enable.Extensions.Queuing.RabbitMQ
         {
         }
 
-        public IQueueClient GetQueueReference(string queueName)
+        public IQueueClient GetQueueReference(string queueName, string deadLetterQueueName = null)
         {
             if (string.IsNullOrWhiteSpace(queueName))
             {
                 throw new ArgumentException(nameof(queueName));
             }
 
-            return new RabbitMQQuorumQueueClient(ConnectionFactory, queueName, QueueMode);
+            return new RabbitMQQuorumQueueClient(ConnectionFactory, queueName, QueueMode, deadLetterQueueName);
         }
     }
 }

--- a/test/Enable.Extensions.Queuing.Discovery.Tests/DiscoveryTests.cs
+++ b/test/Enable.Extensions.Queuing.Discovery.Tests/DiscoveryTests.cs
@@ -25,7 +25,7 @@ namespace Enable.Extensions.Queuing.Discovery.Tests
             // Arrange
             var queueClient = new Mock<IQueueClient>();
             var queueClientFactory = new Mock<IQueueClientFactory>();
-            queueClientFactory.Setup(o => o.GetQueueReference(QueueName)).Returns(queueClient.Object);
+            queueClientFactory.Setup(o => o.GetQueueReference(QueueName, It.IsAny<string>())).Returns(queueClient.Object);
 
             var job = new TestJob();
 
@@ -40,7 +40,7 @@ namespace Enable.Extensions.Queuing.Discovery.Tests
 
             // Assert
             queueClientFactory.Verify(
-                o => o.GetQueueReference(QueueName),
+                o => o.GetQueueReference(QueueName, It.IsAny<string>()),
                 Times.Once);
 
             queueClient.Verify(
@@ -58,7 +58,7 @@ namespace Enable.Extensions.Queuing.Discovery.Tests
 
             var queueClient = new Mock<IQueueClient>();
             var queueClientFactory = new Mock<IQueueClientFactory>();
-            queueClientFactory.Setup(o => o.GetQueueReference(QueueName)).Returns(queueClient.Object);
+            queueClientFactory.Setup(o => o.GetQueueReference(QueueName, It.IsAny<string>())).Returns(queueClient.Object);
 
             var services = new ServiceCollection();
             services.AddSingleton(new TestJob());


### PR DESCRIPTION
Add optional dead letter queue name parameter 

Required for this tasks:
- https://enableinternationalltd.atlassian.net/browse/ICE-661
- https://enableinternationalltd.atlassian.net/browse/ICE-1287


Specifically for interacting with the Express queue from DT API


https://github.com/EnableSoftware/Enable.Extensions.Queuing/issues/39